### PR TITLE
Add a fix for infinite file

### DIFF
--- a/fresh.conf
+++ b/fresh.conf
@@ -4,7 +4,7 @@ build_name:        runner-build
 build_log:         runner-build-errors.log
 valid_ext:         .go, .tpl, .tmpl, .html, .txt
 no_rebuild_ext:    .tpl, .tmpl, .html
-ignored:           assets, tmp
+ignored:           assets, tmp, vendor
 build_delay:       600
 colors:            1
 log_color_main:    cyan


### PR DESCRIPTION
This is to have a way to handle way too many files being watched by
fresh. This ignores the "vendor" directory.

Signed-off-by: Farhaan Bukhsh <farhaan.bukhsh@gmail.com>